### PR TITLE
fix testing empty module

### DIFF
--- a/src/Pukeko.jl
+++ b/src/Pukeko.jl
@@ -8,7 +8,7 @@ module Pukeko
 
     """
         TEST_PREFIX
-    
+
     Functions with this string at the the start of their name will be treated as
     self-contained sets of tests.
     """
@@ -16,7 +16,7 @@ module Pukeko
 
     """
         TestException
-    
+
     The `Exception`` thrown when a Pukeko test fails. Used by `run_tests` to
     distinguish between test errors and unexpected errors.
     """
@@ -205,7 +205,7 @@ module Pukeko
             error("Some tests failed!")
         end
         # All passed, output statistics.
-        total_time = sum(elapsed for (_, elapsed) in test_elapsed_time)
+        total_time = sum(values(test_elapsed_time))
         println("$(test_functions) test function(s) ran successfully ",
                 "in module $(module_name) ",
                 @sprintf("(%.2f seconds)", total_time / 1e9))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,4 +83,8 @@ end
 @assert should_not_run
 @assert FailSlowTests.should_be_one == 1
 
+module Empty
+end
+Pukeko.run_tests(Empty)
+
 include("base_int.jl")


### PR DESCRIPTION
Would otherwise fail with

```
ERROR: ArgumentError: reducing over an empty collection is not allowed
Stacktrace:
 [1] _empty_reduce_error() at ./reduce.jl:214
 [2] mapreduce_empty_iter(::Function, ::Function, ::Base.Generator{Dict{String,UInt64},getfield(Pukeko, Symbol("##2#4"))}, ::Base.EltypeUnknown) at ./reduce.jl:259
 [3] mapfoldl_impl at ./reduce.jl:55 [inlined]
 [4] #mapfoldl#170 at ./reduce.jl:70 [inlined]
 [5] mapfoldl at ./reduce.jl:70 [inlined]
 [6] #mapreduce#174 at ./reduce.jl:203 [inlined]
 [7] mapreduce at ./reduce.jl:203 [inlined]
 [8] sum at ./reduce.jl:397 [inlined]
 [9] sum at ./reduce.jl:414 [inlined]
```